### PR TITLE
[WIP] Webpack v4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-webpack-plugin-assets-fix",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "fix assets(js/css) path in html files while building multiple entry files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
⚠️ I've not tested if this actually works; but it at least stops the below error being produced which is all I care about right now. (This is with `html-webpack-plugin@3.2.0` - I've not tried it with `html-webpack-plugin@next` yet.)

When you look at the diff, [add `?w=1` to the URL](https://github.com/lkiarest/html-webpack-plugin-assets-fix/pull/2/files?w=1) so you ignore the whitespace changes; all I've done is added promise compatibility.

You can install from my GitHub repo directly: `yarn add benjie/html-webpack-plugin-assets-fix#webpack-v4`

Here's the error I was getting:

```
ERROR in   TypeError: callback is not a function
  
  - index.js:67 
    [project]/[html-webpack-plugin-assets-fix]/index.js:67:17
  
  
  - new Promise
  
  
  - index.js:673 
    [project]/[html-webpack-plugin]/index.js:673:47
  
  - index.js:178 Promise.resolve.then.then.then.then.then.then.html
    [project]/[html-webpack-plugin]/index.js:178:18
  
```

Relevant links:

- https://github.com/jantimon/html-webpack-plugin/pull/953
- https://github.com/jantimon/html-webpack-plugin/issues/875